### PR TITLE
Fix for mid-word emoctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 remark-emoji
 ============
-[![CI][ci-badge]][ci]
-[![npm][npm-badge]][npm]
 
-[remark-emoji][npm] is a [remark](https://github.com/remarkjs/remark) plugin to replace `:emoji:` to real UTF-8
-emojis in Markdown text. This plugin is built on top of [node-emoji](https://www.npmjs.com/package/node-emoji).
-The accessibility support and [Emoticon](https://en.wikipedia.org/wiki/Emoticon) support are optionally available.
+This is a fork of [remark-emoji](https://github.com/rhysd/remark-emoji) with a fix for mid-word emoctions bug, suggested by [benkenawell](https://github.com/benkenawell) in his [PR](https://github.com/rhysd/remark-emoji/pull/37).
 
 ## Demo
 

--- a/test.ts
+++ b/test.ts
@@ -200,6 +200,9 @@ describe('remark-emoji', function () {
 
         it('handles emoji shortcodes (emoticon)', async function () {
             const tests: Record<string, string> = {
+                'with space :o, and comma': 'with space 😮, and comma\n',
+                'WARN:Danger': 'WARN:Danger\n',
+                'https://github.com': 'https://github.com\n',
                 ':p': '😛\n',
                 ':-)': '😃\n',
                 'With-in some text :-p, also with some  :o spaces :-)!':


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Enhances the emoticon detection and replacement functionality in the <code>remark-emoji</code> plugin. Modifies the regular expression for short emoticons to prevent mid-word matches, updates the <code>replaceEmoticon</code> function to handle more edge cases, and adds new test cases to verify the changes. Updates the README to reflect that this is a fork addressing a specific bug.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/remark-emoji/1?tool=ast&topic=Emoticon+Detection>Emoticon Detection</a>
        </td><td>Improves the detection and replacement of emoticons within text to prevent mid-word matches and handle more edge cases.<details><summary>Modified files (2)</summary><ul><li>test.ts</li>
<li>index.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lin90162@yahoo.co.jp</td><td>prefer-rehype-sanitize...</td><td>May 19, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://main.baz.ninja/changes/baz-scm/remark-emoji/1?tool=ast&topic=Documentation+Update>Documentation Update</a>
        </td><td>Updates the README to reflect that this is a fork addressing a specific bug related to mid-word emoticons.<details><summary>Modified files (1)</summary><ul><li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lin90162@yahoo.co.jp</td><td>prefer-rehype-sanitize...</td><td>May 19, 2024</td></tr>
<tr><td>i@guoyunhe.me</td><td>support-customEmojis</td><td>January 09, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @omriel1 and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/remark-emoji/1?tool=ast>(Baz)</a>.
    